### PR TITLE
fix: 波動砲でネコカボチャを撃つ際のバグを修正

### DIFF
--- a/SuperNewRoles/Modules/CustomDeath.cs
+++ b/SuperNewRoles/Modules/CustomDeath.cs
@@ -82,7 +82,7 @@ public static class CustomDeathExtensions
             case CustomDeathType.WaveCannon:
                 if (!TryKillEvent.Invoke(source, ref player).RefSuccess)
                     break;
-                player.Player.MurderPlayer(player.Player, MurderResultFlags.Succeeded);
+                source.Player.MurderPlayer(player.Player, MurderResultFlags.Succeeded);
                 FinalStatusManager.SetFinalStatus(player, FinalStatus.WaveCannon);
                 MurderDataManager.AddMurderData(source, player);
                 break;
@@ -160,6 +160,7 @@ public static class CustomDeathExtensions
             case CustomDeathType.SuicideSecrets:
                 player.Player.Exiled();
                 FinalStatusManager.SetFinalStatus(player, FinalStatus.Suicide);
+                // 自殺なのでMurderEventは発火しない
                 break;
             case CustomDeathType.BuskerFakeDeath:
                 player.Player.Exiled();

--- a/SuperNewRoles/Roles/Impostor/NekoKabocha.cs
+++ b/SuperNewRoles/Roles/Impostor/NekoKabocha.cs
@@ -73,6 +73,10 @@ public class NekoKabochaRevenge : AbilityBase
     {
         if (data.target != null && data.target == ExPlayerControl.LocalPlayer && data.killer != null)
         {
+            // 自殺の場合は復讐しない（無限ループ防止）
+            if (data.killer == data.target)
+                return;
+
             bool canRevenge = false;
             ExPlayerControl killer = data.killer;
 


### PR DESCRIPTION
- ネコカボチャの無限自殺バグを修正（自殺の場合は復讐しないように制御）
- 波動砲がネコカボチャに復讐されない問題を修正（WaveCannonの殺害処理を正しく修正）

🤖 Generated with [Claude Code](https://claude.ai/code)